### PR TITLE
Fix URLFrontier domain extraction

### DIFF
--- a/include/search_engine/storage/ContentStorage.h
+++ b/include/search_engine/storage/ContentStorage.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace search_engine {
 namespace storage {

--- a/src/crawler/URLFrontier.cpp
+++ b/src/crawler/URLFrontier.cpp
@@ -117,7 +117,8 @@ std::chrono::system_clock::time_point URLFrontier::getLastVisitTime(const std::s
 }
 
 std::string URLFrontier::extractDomain(const std::string& url) const {
-    static const std::regex domainRegex(R"(https?://([^/]+))");
+    // Extract host portion without scheme and port
+    static const std::regex domainRegex(R"(https?://([^/:]+))", std::regex::icase);
     std::smatch matches;
     if (std::regex_search(url, matches, domainRegex) && matches.size() > 1) {
         std::string domain = matches[1].str();


### PR DESCRIPTION
## Summary
- strip port numbers when extracting domain names
- include `<unordered_map>` in `ContentStorage.h`

## Testing
- `cmake .. -DBUILD_TESTS=ON` *(fails: Could not find `mongocxx`)*

------
https://chatgpt.com/codex/tasks/task_e_68442c8c4a088321bda75f7e238297f7