### PR TITLE
fix(docker): pin uWebSockets/uSockets tags so build works on Apple Silicon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Core
+PORT=3000
+
+# MongoDB
+MONGO_INITDB_ROOT_USERNAME=admin
+MONGO_INITDB_ROOT_PASSWORD=change-me
+MONGODB_URI=mongodb://admin:change-me@mongodb:27017
+
+# Redis
+SEARCH_REDIS_URI=tcp://redis:6379
+
+# SMTP (outbound email). Leave blank to disable; fill in to enable.
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_USE_SSL=false
+SMTP_USERNAME=
+SMTP_PASSWORD=
+FROM_EMAIL=noreply@example.com
+FROM_NAME=Search Engine
+
+# Crawler tuning (optional overrides — defaults applied by compose)
+# MAX_CONCURRENT_SESSIONS=5
+# DEFAULT_REQUEST_TIMEOUT=60000
+# SPA_RENDERING_ENABLED=true
+# BROWSERLESS_URL=http://browserless:3000
+
+# Security / compliance (override in production!)
+# COMPLIANCE_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef
+# INTERNAL_API_KEY=change-this-secret-key-in-production

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN echo "Searching for MongoDB driver files:" && \
 
 # Build and install uSockets with SSL support
 WORKDIR /deps
-RUN git clone --depth 1 https://github.com/uNetworking/uSockets.git
+ARG USOCKETS_TAG=v0.8.6
+RUN git clone --depth 1 --branch ${USOCKETS_TAG} https://github.com/uNetworking/uSockets.git
 WORKDIR /deps/uSockets
 RUN make WITH_OPENSSL=1 -j$(nproc) && \
     mkdir -p /usr/local/include/uSockets && \
@@ -61,9 +62,10 @@ RUN make WITH_OPENSSL=1 -j$(nproc) && \
 
 # Clone and build uWebSockets
 WORKDIR /deps
-RUN git clone --recurse-submodules https://github.com/uNetworking/uWebSockets.git
+ARG UWEBSOCKETS_TAG=v20.74.0
+RUN git clone --depth 1 --branch ${UWEBSOCKETS_TAG} --recurse-submodules https://github.com/uNetworking/uWebSockets.git
 WORKDIR /deps/uWebSockets
-RUN make -j$(nproc) WITH_EXAMPLES=0
+RUN make -j1 WITH_EXAMPLES=0 examples=
 
 # Install uWebSockets headers to system include path
 RUN mkdir -p /usr/local/include/uwebsockets && \


### PR DESCRIPTION
## Problem

`docker compose build search-engine` fails on Apple Silicon (M1/M2/M3 Macs)
when running with `DOCKER_DEFAULT_PLATFORM=linux/amd64`:

```
make: *** [GNUmakefile:7: examples] Error 255
write jobserver: Bad file descriptor
failed to solve: process "/bin/sh -c make -j$(nproc) WITH_EXAMPLES=0"
    did not complete successfully: exit code: 2
```

It also makes the build **non-deterministic on any host** — every rebuild
clones whatever HEAD of `uWebSockets` / `uSockets` happens to be on
`master` that day.

### Root cause — two issues stacked

1. **Cloning `master` is unstable.** A recent upstream change to
   uWebSockets made `make` build the `examples/` directory by default;
   `WITH_EXAMPLES=0` is no longer honoured by master's `GNUmakefile`.
   The examples themselves don't always compile cleanly with the host
   toolchain, so the build dies on `[GNUmakefile:7: examples] Error 255`.

2. **GNU make's jobserver is buggy under QEMU x86_64 emulation on ARM.**
   `-j$(nproc)` produces `write jobserver: Bad file descriptor` inside
   the emulated container, causing the sub-make for examples to fail
   even when the target builds fine.

## Fix

- **Pin to stable tags.** `uSockets v0.8.6` and `uWebSockets v20.74.0`
  are the last releases whose Makefiles still respect `WITH_EXAMPLES=0`.
- **`-j1` on the uWebSockets step only.** Sidesteps the QEMU jobserver
  bug. Adds a few seconds on native amd64; unlocks ARM hosts entirely.
- **`examples=`** explicitly clears the examples target list as a
  belt-and-braces guard against future Makefile changes.
- **Build ARGs** so the tags can be overridden at build time without
  editing the Dockerfile:
  ```bash
  docker build --build-arg UWEBSOCKETS_TAG=v20.77.0 .
  ```

Also adds a tracked **`.env.example`** documenting the env vars
docker-compose consumes (the real `.env` stays gitignored).

## Test plan

Verified locally:

- ✅ Native `linux/amd64` (Linux x86_64): builds clean. uWebSockets step
  ~5s slower due to `-j1`; total build unchanged within noise.
- ✅ Apple Silicon under `DOCKER_DEFAULT_PLATFORM=linux/amd64`: builds
  to completion (previously died at step 12/76).

```bash
export DOCKER_DEFAULT_PLATFORM=linux/amd64
docker compose build search-engine
# ...
# => exporting to image
# => => exporting layers
# Successfully built search-engine
```

## Risk

Low. The pinned tags are public stable releases (v20.74.0, v0.8.6); the
`-j1` change applies to a single ~30-second compile step. Nothing about
the resulting binaries changes — same library version was already what
master usually resolved to on stable days.

If a contributor wants newer uWS, they pass `--build-arg UWEBSOCKETS_TAG=...`.