### PR TITLE
feat(auth): user session isolation with JWT auth and RBAC (closes #13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ file(GLOB_RECURSE MAIN_SOURCES "src/*.cpp" "src/main.cpp")
 # Remove crawler sources, storage sources, test sources, and common sources from MAIN_SOURCES
 list(FILTER MAIN_SOURCES EXCLUDE REGEX ".*crawler/.*\\.cpp$")
 list(FILTER MAIN_SOURCES EXCLUDE REGEX ".*storage/.*\\.cpp$")
+list(FILTER MAIN_SOURCES EXCLUDE REGEX ".*src/auth/.*\\.cpp$")  # compiled into storage lib (#13)
 list(FILTER MAIN_SOURCES EXCLUDE REGEX ".*test.*\\.cpp$")
 list(FILTER MAIN_SOURCES EXCLUDE REGEX ".*common/.*\\.cpp$")
 list(FILTER MAIN_SOURCES EXCLUDE REGEX ".*scoring/.*\\.cpp$")

--- a/include/search_engine/auth/Base64Url.h
+++ b/include/search_engine/auth/Base64Url.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <vector>
+
+namespace search_engine { namespace auth {
+
+/**
+ * @brief Base64URL (RFC 4648 §5) encoding/decoding — no padding.
+ *
+ * Used for JWT segment encoding and for storing salt/hash bytes in the
+ * compact password hash string. Header-only; depends on nothing.
+ */
+namespace Base64Url {
+
+inline const char* alphabet() {
+    return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+}
+
+inline std::string encode(const unsigned char* data, size_t len) {
+    static const char* alpha = alphabet();
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    size_t i = 0;
+    while (i + 3 <= len) {
+        uint32_t triple = (uint32_t(data[i]) << 16) | (uint32_t(data[i+1]) << 8) | uint32_t(data[i+2]);
+        out.push_back(alpha[(triple >> 18) & 0x3F]);
+        out.push_back(alpha[(triple >> 12) & 0x3F]);
+        out.push_back(alpha[(triple >>  6) & 0x3F]);
+        out.push_back(alpha[(triple      ) & 0x3F]);
+        i += 3;
+    }
+    if (i < len) {
+        uint32_t rem = uint32_t(data[i]) << 16;
+        if (i + 1 < len) rem |= uint32_t(data[i+1]) << 8;
+        out.push_back(alpha[(rem >> 18) & 0x3F]);
+        out.push_back(alpha[(rem >> 12) & 0x3F]);
+        if (i + 1 < len) {
+            out.push_back(alpha[(rem >>  6) & 0x3F]);
+        }
+    }
+    return out;
+}
+
+inline std::string encode(const std::string& bytes) {
+    return encode(reinterpret_cast<const unsigned char*>(bytes.data()), bytes.size());
+}
+
+inline int charIdx(char c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return 26 + (c - 'a');
+    if (c >= '0' && c <= '9') return 52 + (c - '0');
+    if (c == '-') return 62;
+    if (c == '_') return 63;
+    return -1;
+}
+
+// Returns empty vector on invalid input.
+inline std::vector<unsigned char> decode(const std::string& in) {
+    std::vector<unsigned char> out;
+    out.reserve((in.size() * 3) / 4);
+    uint32_t buf = 0;
+    int bits = 0;
+    for (char c : in) {
+        if (c == '=') break;
+        int v = charIdx(c);
+        if (v < 0) return {};   // invalid char
+        buf = (buf << 6) | uint32_t(v);
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back(static_cast<unsigned char>((buf >> bits) & 0xFF));
+        }
+    }
+    return out;
+}
+
+inline std::string decodeToString(const std::string& in) {
+    auto bytes = decode(in);
+    return std::string(bytes.begin(), bytes.end());
+}
+
+}  // namespace Base64Url
+}}  // namespace

--- a/include/search_engine/auth/Jwt.h
+++ b/include/search_engine/auth/Jwt.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "User.h"
+#include <string>
+#include <chrono>
+#include <optional>
+
+namespace search_engine { namespace auth {
+
+/**
+ * @brief Claims encoded into and decoded from a JWT — issue #13.
+ *
+ * Minimal set tailored to this app:
+ *   sub:      user id
+ *   username: user's username
+ *   role:     "user" | "admin"
+ *   iat:      issued-at epoch seconds
+ *   exp:      expiry epoch seconds
+ */
+struct JwtClaims {
+    std::string sub;
+    std::string username;
+    Role role{Role::USER};
+    int64_t iat{0};
+    int64_t exp{0};
+};
+
+/**
+ * @brief HS256 JWT issuer/verifier backed by OpenSSL HMAC.
+ *
+ * The secret should come from env JWT_SECRET (production). For dev a
+ * fallback is allowed but a warning is logged at first use.
+ *
+ * Implementation in src/auth/Jwt.cpp.
+ */
+class JwtIssuer {
+public:
+    explicit JwtIssuer(std::string secret,
+                       std::chrono::seconds defaultTtl = std::chrono::hours(24))
+        : secret_(std::move(secret)), defaultTtl_(defaultTtl) {}
+
+    // Build the secret from the JWT_SECRET env var; falls back to a built-in
+    // dev secret (and the caller should log a warning).
+    static std::string secretFromEnvOrDev();
+
+    // Issue a signed JWT for the given user.
+    std::string issue(const User& user) const;
+    std::string issue(const User& user, std::chrono::seconds ttl) const;
+
+    // Verify token signature + expiration. Returns claims on success.
+    std::optional<JwtClaims> verify(const std::string& token) const;
+
+private:
+    std::string secret_;
+    std::chrono::seconds defaultTtl_;
+};
+
+}}  // namespace

--- a/include/search_engine/auth/PasswordHasher.h
+++ b/include/search_engine/auth/PasswordHasher.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+namespace search_engine { namespace auth {
+
+/**
+ * @brief Password hashing (PBKDF2-HMAC-SHA256) — issue #13.
+ *
+ * Encoded form: "iter$saltB64$hashB64" (base64url, no padding).
+ * Stored on User::passwordHash; never the plaintext.
+ *
+ * Implementation lives in src/auth/PasswordHasher.cpp (links OpenSSL).
+ */
+class PasswordHasher {
+public:
+    // Default iteration count. Tune up over time; verify is parameterized
+    // by the iteration count embedded in the stored string, so existing
+    // hashes keep working.
+    static constexpr int DEFAULT_ITERATIONS = 100000;
+    static constexpr size_t SALT_BYTES = 16;
+    static constexpr size_t HASH_BYTES = 32;  // SHA-256
+
+    // Hash a plaintext password. Returns encoded string ready to store.
+    static std::string hash(const std::string& password,
+                            int iterations = DEFAULT_ITERATIONS);
+
+    // Verify a candidate password against a stored encoded hash.
+    // Returns false for any malformed input (constant-time on mismatch).
+    static bool verify(const std::string& password, const std::string& stored);
+};
+
+}}  // namespace

--- a/include/search_engine/auth/User.h
+++ b/include/search_engine/auth/User.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+#include <chrono>
+
+namespace search_engine { namespace auth {
+
+/**
+ * @brief User roles for role-based access control (issue #13).
+ *
+ * - USER: can only see and operate on their own resources (crawl sessions, etc.)
+ * - ADMIN: can see and operate on resources of any user.
+ */
+enum class Role {
+    USER = 0,
+    ADMIN = 1
+};
+
+inline const char* roleToString(Role r) {
+    switch (r) {
+        case Role::USER: return "user";
+        case Role::ADMIN: return "admin";
+    }
+    return "user";
+}
+
+inline Role roleFromString(const std::string& s) {
+    if (s == "admin" || s == "ADMIN") return Role::ADMIN;
+    return Role::USER;
+}
+
+/**
+ * @brief Persistent user record.
+ *
+ * passwordHash stores the encoded PBKDF2 output ("iter$saltB64$hashB64");
+ * never the plaintext password.
+ */
+struct User {
+    std::string id;
+    std::string username;
+    std::string passwordHash;
+    Role role{Role::USER};
+    std::chrono::system_clock::time_point createdAt{std::chrono::system_clock::now()};
+};
+
+/**
+ * @brief The authenticated user context for a single request.
+ *
+ * Built from a verified JWT — does NOT include the password hash. Passed to
+ * any code that needs to make ownership / authorization decisions.
+ */
+struct AuthContext {
+    std::string userId;
+    std::string username;
+    Role role{Role::USER};
+
+    bool isAdmin() const { return role == Role::ADMIN; }
+};
+
+}}  // namespace

--- a/include/search_engine/auth/UserStore.h
+++ b/include/search_engine/auth/UserStore.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "User.h"
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+#include <optional>
+#include <atomic>
+#include <sstream>
+
+namespace search_engine { namespace auth {
+
+/**
+ * @brief Storage interface for users (issue #13).
+ *
+ * In-memory default impl is provided. A MongoDB-backed implementation can
+ * subclass without changing callers.
+ */
+class IUserStore {
+public:
+    virtual ~IUserStore() = default;
+
+    // Returns false if username already exists. Generates id and stamps createdAt.
+    virtual bool create(User& user) = 0;
+    virtual std::optional<User> findByUsername(const std::string& username) const = 0;
+    virtual std::optional<User> findById(const std::string& id) const = 0;
+    virtual std::vector<User> all() const = 0;
+    virtual size_t size() const = 0;
+    virtual void clear() = 0;
+};
+
+class InMemoryUserStore : public IUserStore {
+public:
+    bool create(User& user) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (byUsername_.find(user.username) != byUsername_.end()) {
+            return false;
+        }
+        if (user.id.empty()) {
+            // Simple monotonic id; replace with UUID for production.
+            user.id = "u_" + std::to_string(++counter_);
+        }
+        if (user.createdAt.time_since_epoch().count() == 0) {
+            user.createdAt = std::chrono::system_clock::now();
+        }
+        users_[user.id] = user;
+        byUsername_[user.username] = user.id;
+        return true;
+    }
+
+    std::optional<User> findByUsername(const std::string& username) const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = byUsername_.find(username);
+        if (it == byUsername_.end()) return std::nullopt;
+        auto uit = users_.find(it->second);
+        if (uit == users_.end()) return std::nullopt;
+        return uit->second;
+    }
+
+    std::optional<User> findById(const std::string& id) const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = users_.find(id);
+        if (it == users_.end()) return std::nullopt;
+        return it->second;
+    }
+
+    std::vector<User> all() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::vector<User> out;
+        out.reserve(users_.size());
+        for (const auto& [_, u] : users_) out.push_back(u);
+        return out;
+    }
+
+    size_t size() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return users_.size();
+    }
+
+    void clear() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        users_.clear();
+        byUsername_.clear();
+        counter_ = 0;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, User> users_;        // id -> user
+    std::unordered_map<std::string, std::string> byUsername_;  // username -> id
+    uint64_t counter_{0};
+};
+
+}}  // namespace

--- a/include/search_engine/crawler/CrawlerManager.h
+++ b/include/search_engine/crawler/CrawlerManager.h
@@ -11,6 +11,7 @@
 #include "Crawler.h"
 #include "models/CrawlConfig.h"
 #include "models/CrawlResult.h"
+#include "../auth/User.h"
 #include "../storage/ContentStorage.h"
 
 // Forward declaration for completion callback
@@ -33,19 +34,24 @@ struct CrawlSession {
     std::atomic<bool> isCompleted{false};
     std::thread crawlThread;
     CrawlCompletionCallback completionCallback;
-    
-    CrawlSession(const std::string& sessionId, std::unique_ptr<Crawler> crawlerInstance, 
-                 CrawlCompletionCallback callback = nullptr)
+    // Owner of this session. Empty string means "system / anonymous"
+    // (legacy behaviour); when set, only the owner or admins can access. #13
+    std::string userId;
+
+    CrawlSession(const std::string& sessionId, std::unique_ptr<Crawler> crawlerInstance,
+                 CrawlCompletionCallback callback = nullptr,
+                 std::string ownerUserId = "")
         : id(sessionId), crawler(std::move(crawlerInstance)), createdAt(std::chrono::system_clock::now()),
-          completionCallback(std::move(callback)) {}
-    
+          completionCallback(std::move(callback)), userId(std::move(ownerUserId)) {}
+
     CrawlSession(CrawlSession&& other) noexcept
         : id(std::move(other.id))
         , crawler(std::move(other.crawler))
         , createdAt(other.createdAt)
         , isCompleted(other.isCompleted.load())
         , crawlThread(std::move(other.crawlThread))
-        , completionCallback(std::move(other.completionCallback)) {}
+        , completionCallback(std::move(other.completionCallback))
+        , userId(std::move(other.userId)) {}
     
     CrawlSession(const CrawlSession&) = delete;
     CrawlSession& operator=(const CrawlSession&) = delete;
@@ -65,15 +71,35 @@ public:
      * @param completionCallback Optional callback to execute when crawl completes
      * @return Session ID of the started crawl
      */
-    std::string startCrawl(const std::string& url, const CrawlConfig& config, bool force = false, 
-                          CrawlCompletionCallback completionCallback = nullptr);
-    
+    std::string startCrawl(const std::string& url, const CrawlConfig& config, bool force = false,
+                          CrawlCompletionCallback completionCallback = nullptr,
+                          const std::string& ownerUserId = "");
+
     std::vector<CrawlResult> getCrawlResults(const std::string& sessionId);
     std::string getCrawlStatus(const std::string& sessionId);
     bool stopCrawl(const std::string& sessionId);
     std::vector<std::string> getActiveSessions();
     void cleanupCompletedSessions();
     size_t getActiveSessionCount();
+
+    // ---- User-aware variants (issue #13) ----
+    // Each returns the same data as the legacy variant if the AuthContext is
+    // an admin OR the session is owned by ctx.userId. Otherwise returns the
+    // "not found" / "not authorised" equivalent (empty results, "not_found"
+    // status, false for stopCrawl). Empty owner on a session = anyone may
+    // access (back-compat for legacy callers).
+    std::vector<CrawlResult> getCrawlResults(const std::string& sessionId,
+                                             const search_engine::auth::AuthContext& ctx);
+    std::string getCrawlStatus(const std::string& sessionId,
+                               const search_engine::auth::AuthContext& ctx);
+    bool stopCrawl(const std::string& sessionId,
+                   const search_engine::auth::AuthContext& ctx);
+    std::vector<std::string> getActiveSessions(const search_engine::auth::AuthContext& ctx);
+
+    // Helper exposed for controllers and tests: is `ctx` allowed to touch
+    // the session owned by `sessionOwnerId`?
+    static bool canAccess(const std::string& sessionOwnerId,
+                          const search_engine::auth::AuthContext& ctx);
     
     // Get access to storage for logging
     std::shared_ptr<search_engine::storage::ContentStorage> getStorage() const { return storage_; }

--- a/src/auth/Jwt.cpp
+++ b/src/auth/Jwt.cpp
@@ -1,0 +1,127 @@
+#include "search_engine/auth/Jwt.h"
+#include "search_engine/auth/Base64Url.h"
+
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+#include <nlohmann/json.hpp>
+
+#include <cstdlib>
+#include <stdexcept>
+#include <sstream>
+#include <vector>
+
+namespace search_engine { namespace auth {
+
+namespace {
+    int64_t nowEpochSeconds() {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    }
+
+    std::string hmacSha256(const std::string& key, const std::string& msg) {
+        unsigned char mac[EVP_MAX_MD_SIZE];
+        unsigned int macLen = 0;
+        if (HMAC(EVP_sha256(),
+                 key.data(), static_cast<int>(key.size()),
+                 reinterpret_cast<const unsigned char*>(msg.data()), msg.size(),
+                 mac, &macLen) == nullptr) {
+            throw std::runtime_error("HMAC failed");
+        }
+        return Base64Url::encode(mac, macLen);
+    }
+
+    // Constant-time string comparison.
+    bool constantTimeEqual(const std::string& a, const std::string& b) {
+        if (a.size() != b.size()) return false;
+        unsigned char diff = 0;
+        for (size_t i = 0; i < a.size(); ++i) {
+            diff |= static_cast<unsigned char>(a[i]) ^ static_cast<unsigned char>(b[i]);
+        }
+        return diff == 0;
+    }
+}
+
+std::string JwtIssuer::secretFromEnvOrDev() {
+    const char* env = std::getenv("JWT_SECRET");
+    if (env && *env) return std::string(env);
+    // Dev fallback — caller should log a warning at startup.
+    return "dev-jwt-secret-please-override-via-JWT_SECRET-env";
+}
+
+std::string JwtIssuer::issue(const User& user) const {
+    return issue(user, defaultTtl_);
+}
+
+std::string JwtIssuer::issue(const User& user, std::chrono::seconds ttl) const {
+    nlohmann::json header = {
+        {"alg", "HS256"},
+        {"typ", "JWT"}
+    };
+    auto iat = nowEpochSeconds();
+    auto exp = iat + ttl.count();
+    nlohmann::json payload = {
+        {"sub", user.id},
+        {"username", user.username},
+        {"role", roleToString(user.role)},
+        {"iat", iat},
+        {"exp", exp}
+    };
+    auto h = header.dump();
+    auto p = payload.dump();
+    std::string hb = Base64Url::encode(h);
+    std::string pb = Base64Url::encode(p);
+    std::string signingInput = hb + "." + pb;
+    std::string sig = hmacSha256(secret_, signingInput);
+    return signingInput + "." + sig;
+}
+
+std::optional<JwtClaims> JwtIssuer::verify(const std::string& token) const {
+    auto firstDot = token.find('.');
+    if (firstDot == std::string::npos) return std::nullopt;
+    auto secondDot = token.find('.', firstDot + 1);
+    if (secondDot == std::string::npos) return std::nullopt;
+
+    std::string headerB64 = token.substr(0, firstDot);
+    std::string payloadB64 = token.substr(firstDot + 1, secondDot - firstDot - 1);
+    std::string signature = token.substr(secondDot + 1);
+
+    // Re-compute signature.
+    std::string signingInput = headerB64 + "." + payloadB64;
+    std::string expectedSig;
+    try {
+        expectedSig = hmacSha256(secret_, signingInput);
+    } catch (...) {
+        return std::nullopt;
+    }
+    if (!constantTimeEqual(signature, expectedSig)) return std::nullopt;
+
+    // Decode header — sanity check alg=HS256.
+    auto headerBytes = Base64Url::decode(headerB64);
+    if (headerBytes.empty()) return std::nullopt;
+    nlohmann::json header;
+    try {
+        header = nlohmann::json::parse(std::string(headerBytes.begin(), headerBytes.end()));
+    } catch (...) { return std::nullopt; }
+    if (!header.contains("alg") || header["alg"] != "HS256") return std::nullopt;
+
+    // Decode payload.
+    auto payloadBytes = Base64Url::decode(payloadB64);
+    if (payloadBytes.empty()) return std::nullopt;
+    nlohmann::json payload;
+    try {
+        payload = nlohmann::json::parse(std::string(payloadBytes.begin(), payloadBytes.end()));
+    } catch (...) { return std::nullopt; }
+
+    JwtClaims c;
+    if (payload.contains("sub")) c.sub = payload["sub"].get<std::string>();
+    if (payload.contains("username")) c.username = payload["username"].get<std::string>();
+    if (payload.contains("role")) c.role = roleFromString(payload["role"].get<std::string>());
+    if (payload.contains("iat")) c.iat = payload["iat"].get<int64_t>();
+    if (payload.contains("exp")) c.exp = payload["exp"].get<int64_t>();
+
+    // Expiry check.
+    if (c.exp > 0 && nowEpochSeconds() >= c.exp) return std::nullopt;
+    return c;
+}
+
+}}  // namespace

--- a/src/auth/PasswordHasher.cpp
+++ b/src/auth/PasswordHasher.cpp
@@ -1,0 +1,77 @@
+#include "search_engine/auth/PasswordHasher.h"
+#include "search_engine/auth/Base64Url.h"
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <vector>
+#include <sstream>
+#include <stdexcept>
+#include <cstdlib>
+
+namespace search_engine { namespace auth {
+
+std::string PasswordHasher::hash(const std::string& password, int iterations) {
+    if (iterations <= 0) iterations = DEFAULT_ITERATIONS;
+
+    unsigned char salt[SALT_BYTES];
+    if (RAND_bytes(salt, SALT_BYTES) != 1) {
+        throw std::runtime_error("PasswordHasher: RAND_bytes failed");
+    }
+
+    unsigned char out[HASH_BYTES];
+    if (PKCS5_PBKDF2_HMAC(password.data(), static_cast<int>(password.size()),
+                          salt, SALT_BYTES,
+                          iterations,
+                          EVP_sha256(),
+                          HASH_BYTES, out) != 1) {
+        throw std::runtime_error("PasswordHasher: PKCS5_PBKDF2_HMAC failed");
+    }
+
+    std::ostringstream ss;
+    ss << iterations << "$"
+       << Base64Url::encode(salt, SALT_BYTES) << "$"
+       << Base64Url::encode(out, HASH_BYTES);
+    return ss.str();
+}
+
+bool PasswordHasher::verify(const std::string& password, const std::string& stored) {
+    // Parse "iter$saltB64$hashB64".
+    auto firstDollar = stored.find('$');
+    if (firstDollar == std::string::npos) return false;
+    auto secondDollar = stored.find('$', firstDollar + 1);
+    if (secondDollar == std::string::npos) return false;
+
+    int iterations = 0;
+    try {
+        iterations = std::stoi(stored.substr(0, firstDollar));
+    } catch (...) {
+        return false;
+    }
+    if (iterations <= 0) return false;
+
+    auto saltStr = stored.substr(firstDollar + 1, secondDollar - firstDollar - 1);
+    auto hashStr = stored.substr(secondDollar + 1);
+
+    auto salt = Base64Url::decode(saltStr);
+    auto expected = Base64Url::decode(hashStr);
+    if (salt.empty() || expected.empty()) return false;
+    if (expected.size() != HASH_BYTES) return false;
+
+    std::vector<unsigned char> candidate(HASH_BYTES);
+    if (PKCS5_PBKDF2_HMAC(password.data(), static_cast<int>(password.size()),
+                          salt.data(), static_cast<int>(salt.size()),
+                          iterations,
+                          EVP_sha256(),
+                          HASH_BYTES, candidate.data()) != 1) {
+        return false;
+    }
+
+    // Constant-time comparison.
+    unsigned char diff = 0;
+    for (size_t i = 0; i < HASH_BYTES; ++i) {
+        diff |= candidate[i] ^ expected[i];
+    }
+    return diff == 0;
+}
+
+}}  // namespace

--- a/src/controllers/AuthController.cpp
+++ b/src/controllers/AuthController.cpp
@@ -1,0 +1,169 @@
+#include "AuthController.h"
+#include "../../include/Logger.h"
+#include "../../include/search_engine/auth/PasswordHasher.h"
+#include <nlohmann/json.hpp>
+#include <mutex>
+
+using namespace search_engine::auth;
+
+namespace {
+    std::once_flag g_authInitFlag;
+    std::unique_ptr<IUserStore> g_userStore;
+    std::unique_ptr<JwtIssuer> g_jwtIssuer;
+    bool g_devSecretWarned = false;
+
+    void ensureAuthInitialized() {
+        std::call_once(g_authInitFlag, []() {
+            g_userStore = std::make_unique<InMemoryUserStore>();
+            auto secret = JwtIssuer::secretFromEnvOrDev();
+            if (std::getenv("JWT_SECRET") == nullptr) {
+                LOG_WARNING("JWT_SECRET env var not set — using built-in dev secret. "
+                            "DO NOT run in production without setting JWT_SECRET.");
+                g_devSecretWarned = true;
+            }
+            g_jwtIssuer = std::make_unique<JwtIssuer>(secret);
+            LOG_INFO("Auth subsystem initialized");
+        });
+    }
+}
+
+AuthController::AuthController() { ensureAuthInitialized(); }
+
+IUserStore* AuthController::userStore() {
+    ensureAuthInitialized();
+    return g_userStore.get();
+}
+
+JwtIssuer* AuthController::jwtIssuer() {
+    ensureAuthInitialized();
+    return g_jwtIssuer.get();
+}
+
+std::optional<AuthContext> AuthController::extractAuth(uWS::HttpRequest* req) {
+    ensureAuthInitialized();
+    if (!req) return std::nullopt;
+    auto authHeader = req->getHeader("authorization");
+    if (authHeader.empty()) return std::nullopt;
+    const std::string prefix = "Bearer ";
+    if (authHeader.size() <= prefix.size() ||
+        std::string(authHeader.substr(0, prefix.size())) != prefix) {
+        return std::nullopt;
+    }
+    std::string token(authHeader.substr(prefix.size()));
+    auto claims = g_jwtIssuer->verify(token);
+    if (!claims.has_value()) return std::nullopt;
+
+    AuthContext ctx;
+    ctx.userId = claims->sub;
+    ctx.username = claims->username;
+    ctx.role = claims->role;
+    return ctx;
+}
+
+namespace {
+    // Read JSON body asynchronously, then run `cb`. Bounds enforced to avoid
+    // unbounded buffering.
+    template <typename Cb>
+    void readJsonBody(uWS::HttpResponse<false>* res, Cb cb) {
+        auto buffer = std::make_shared<std::string>();
+        res->onData([res, buffer, cb = std::move(cb)](std::string_view chunk, bool last) mutable {
+            buffer->append(chunk.data(), chunk.size());
+            if (buffer->size() > 64 * 1024) {
+                res->writeStatus("413 Payload Too Large")->end("Body too large");
+                return;
+            }
+            if (!last) return;
+            try {
+                auto j = nlohmann::json::parse(*buffer);
+                cb(j);
+            } catch (const std::exception& e) {
+                res->writeStatus("400 Bad Request")
+                   ->writeHeader("Content-Type", "application/json")
+                   ->end(std::string("{\"error\":\"Invalid JSON: ") + e.what() + "\"}");
+            }
+        });
+        res->onAborted([]() {});
+    }
+}
+
+void AuthController::registerUser(uWS::HttpResponse<false>* res, uWS::HttpRequest* /*req*/) {
+    ensureAuthInitialized();
+    readJsonBody(res, [res](const nlohmann::json& body) {
+        std::string username = body.value("username", "");
+        std::string password = body.value("password", "");
+        std::string roleStr = body.value("role", "user");
+        if (username.empty() || password.size() < 8) {
+            badRequest(res, "username required and password must be >= 8 chars");
+            return;
+        }
+        if (g_userStore->findByUsername(username).has_value()) {
+            res->writeStatus("409 Conflict")
+               ->writeHeader("Content-Type", "application/json")
+               ->end("{\"error\":\"username already exists\"}");
+            return;
+        }
+        User u;
+        u.username = username;
+        u.passwordHash = PasswordHasher::hash(password);
+        u.role = roleFromString(roleStr);
+        if (!g_userStore->create(u)) {
+            serverError(res, "Failed to create user");
+            return;
+        }
+        nlohmann::json response = {
+            {"id", u.id},
+            {"username", u.username},
+            {"role", roleToString(u.role)}
+        };
+        json(res, response, "201 Created");
+    });
+}
+
+void AuthController::login(uWS::HttpResponse<false>* res, uWS::HttpRequest* /*req*/) {
+    ensureAuthInitialized();
+    readJsonBody(res, [res](const nlohmann::json& body) {
+        std::string username = body.value("username", "");
+        std::string password = body.value("password", "");
+        if (username.empty() || password.empty()) {
+            badRequest(res, "username and password required");
+            return;
+        }
+        auto u = g_userStore->findByUsername(username);
+        if (!u.has_value() || !PasswordHasher::verify(password, u->passwordHash)) {
+            // Same response for unknown user and wrong password to avoid
+            // user-enumeration via timing/error difference.
+            res->writeStatus("401 Unauthorized")
+               ->writeHeader("Content-Type", "application/json")
+               ->end("{\"error\":\"invalid credentials\"}");
+            return;
+        }
+        auto token = g_jwtIssuer->issue(*u);
+        nlohmann::json response = {
+            {"token", token},
+            {"tokenType", "Bearer"},
+            {"user", {
+                {"id", u->id},
+                {"username", u->username},
+                {"role", roleToString(u->role)}
+            }}
+        };
+        json(res, response);
+    });
+}
+
+void AuthController::me(uWS::HttpResponse<false>* res, uWS::HttpRequest* req) {
+    ensureAuthInitialized();
+    auto ctx = extractAuth(req);
+    if (!ctx.has_value()) {
+        res->writeStatus("401 Unauthorized")
+           ->writeHeader("Content-Type", "application/json")
+           ->end("{\"error\":\"missing or invalid token\"}");
+        return;
+    }
+    nlohmann::json response = {
+        {"id", ctx->userId},
+        {"username", ctx->username},
+        {"role", roleToString(ctx->role)}
+    };
+    json(res, response);
+}

--- a/src/controllers/AuthController.h
+++ b/src/controllers/AuthController.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "../../include/routing/Controller.h"
+#include "../../include/search_engine/auth/UserStore.h"
+#include "../../include/search_engine/auth/Jwt.h"
+#include <memory>
+#include <mutex>
+
+/**
+ * @brief Authentication endpoints (issue #13).
+ *
+ * POST /api/auth/register  { username, password, role? }
+ * POST /api/auth/login     { username, password }   -> { token }
+ * GET  /api/auth/me        Authorization: Bearer <token>
+ *
+ * Also exposes a static helper `extractAuth()` used by other controllers
+ * (e.g. SearchController) to read the Bearer token off a request and
+ * resolve it into an AuthContext.
+ */
+class AuthController : public routing::Controller {
+public:
+    AuthController();
+
+    void registerUser(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
+    void login(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
+    void me(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
+
+    // Resolve a request's Bearer token (if any) to an AuthContext. Returns
+    // an empty optional if missing or invalid.
+    static std::optional<search_engine::auth::AuthContext> extractAuth(uWS::HttpRequest* req);
+
+    // Accessors for the singletons (used by SearchController etc.)
+    static search_engine::auth::IUserStore* userStore();
+    static search_engine::auth::JwtIssuer* jwtIssuer();
+};
+
+ROUTE_CONTROLLER(AuthController) {
+    using namespace routing;
+    REGISTER_ROUTE(HttpMethod::POST, "/api/auth/register", registerUser, AuthController);
+    REGISTER_ROUTE(HttpMethod::POST, "/api/auth/login", login, AuthController);
+    REGISTER_ROUTE(HttpMethod::GET,  "/api/auth/me", me, AuthController);
+}

--- a/src/controllers/SearchController.cpp
+++ b/src/controllers/SearchController.cpp
@@ -2,6 +2,8 @@
 #include "../../include/Logger.h"
 #include "../../include/search_engine/crawler/Crawler.h"
 #include "../../include/search_engine/crawler/CrawlerManager.h"
+#include "AuthController.h"
+#include "../../include/search_engine/auth/User.h"
 #include "../../include/search_engine/crawler/PageFetcher.h"
 #include "../../include/search_engine/crawler/models/CrawlConfig.h"
 #include "../../include/search_engine/storage/ContentStorage.h"
@@ -194,10 +196,21 @@ void SearchController::addSiteToCrawl(uWS::HttpResponse<false>* res, uWS::HttpRe
     }
     
     LOG_INFO("IP Address: " + ipAddress + ", User Agent: " + userAgent);
-    
+
+    // Extract auth context BEFORE the async data callback — the request
+    // pointer is not safe to dereference inside onData. #13
+    auto authCtx = AuthController::extractAuth(req);
+    if (!authCtx.has_value()) {
+        res->writeStatus("401 Unauthorized")
+           ->writeHeader("Content-Type", "application/json")
+           ->end("{\"error\":\"authentication required\"}");
+        return;
+    }
+    search_engine::auth::AuthContext ctx = *authCtx;
+
     // Read the request body
     std::string buffer;
-    res->onData([this, res, req, buffer = std::move(buffer), requestStartTime, ipAddress, userAgent](std::string_view data, bool last) mutable {
+    res->onData([this, res, req, buffer = std::move(buffer), requestStartTime, ipAddress, userAgent, ctx](std::string_view data, bool last) mutable {
         buffer.append(data.data(), data.length());
         
         LOG_INFO("addSiteToCrawl: Received data chunk, length: " + std::to_string(data.length()) + ", last: " + (last ? "true" : "false") + ", buffer size: " + std::to_string(buffer.size()));
@@ -271,12 +284,14 @@ void SearchController::addSiteToCrawl(uWS::HttpResponse<false>* res, uWS::HttpRe
                 
                 // Start new crawl session
                 if (g_crawlerManager) {
-                    // Stop previous sessions if requested
+                    // Stop previous sessions if requested. Only the caller's
+                    // own active sessions are visible/stoppable here (admins
+                    // can stop everyone's). #13
                     if (stopPreviousSessions) {
-                        auto activeSessions = g_crawlerManager->getActiveSessions();
-                        LOG_INFO("Stopping " + std::to_string(activeSessions.size()) + " active sessions before starting new crawl");
+                        auto activeSessions = g_crawlerManager->getActiveSessions(ctx);
+                        LOG_INFO("Stopping " + std::to_string(activeSessions.size()) + " active sessions for user " + ctx.userId);
                         for (const auto& activeSessionId : activeSessions) {
-                            g_crawlerManager->stopCrawl(activeSessionId);
+                            g_crawlerManager->stopCrawl(activeSessionId, ctx);
                         }
                     }
                     
@@ -317,8 +332,9 @@ void SearchController::addSiteToCrawl(uWS::HttpResponse<false>* res, uWS::HttpRe
                         };
                     }
                     
-                    // Start new crawl session with completion callback
-                    std::string sessionId = g_crawlerManager->startCrawl(url, config, force, emailCallback);
+                    // Start new crawl session — owner = authenticated user. #13
+                    std::string sessionId = g_crawlerManager->startCrawl(
+                        url, config, force, emailCallback, ctx.userId);
                     
                     LOG_INFO("Started new crawl session: " + sessionId + " for URL: " + url + 
                              " (maxPages: " + std::to_string(maxPages) + 
@@ -587,8 +603,18 @@ void SearchController::search(uWS::HttpResponse<false>* res, uWS::HttpRequest* r
 
 void SearchController::getCrawlStatus(uWS::HttpResponse<false>* res, uWS::HttpRequest* req) {
     LOG_INFO("SearchController::getCrawlStatus called");
-    
+
     try {
+        // Authentication required for any access to session data. #13
+        auto authCtx = AuthController::extractAuth(req);
+        if (!authCtx.has_value()) {
+            res->writeStatus("401 Unauthorized")
+               ->writeHeader("Content-Type", "application/json")
+               ->end("{\"error\":\"authentication required\"}");
+            return;
+        }
+        const search_engine::auth::AuthContext& ctx = *authCtx;
+
         // Parse query parameters
         auto params = parseQuery(req);
         
@@ -615,20 +641,20 @@ void SearchController::getCrawlStatus(uWS::HttpResponse<false>* res, uWS::HttpRe
         
         if (g_crawlerManager) {
             if (sessionIdIt != params.end()) {
-                // Get status for specific session
+                // Get status for specific session (ownership-checked) #13
                 std::string sessionId = sessionIdIt->second;
-                std::string status = g_crawlerManager->getCrawlStatus(sessionId);
-                
+                std::string status = g_crawlerManager->getCrawlStatus(sessionId, ctx);
+
                 if (status == "not_found") {
-                    badRequest(res, "Session not found");
+                    notFound(res, "Session not found");
                     return;
                 }
-                
+
                 response["sessionId"] = sessionId;
                 response["status"] = status;
-                
+
                 if (includeResults) {
-                    auto results = g_crawlerManager->getCrawlResults(sessionId);
+                    auto results = g_crawlerManager->getCrawlResults(sessionId, ctx);
                     nlohmann::json resultsArray = nlohmann::json::array();
                     
                     // Get the most recent results (up to maxResults)
@@ -661,25 +687,25 @@ void SearchController::getCrawlStatus(uWS::HttpResponse<false>* res, uWS::HttpRe
                     response["totalCrawled"] = static_cast<int>(results.size());
                 }
             } else {
-                // Get status for all active sessions
-                auto activeSessions = g_crawlerManager->getActiveSessions();
-                
+                // Get status for active sessions visible to this user. #13
+                auto activeSessions = g_crawlerManager->getActiveSessions(ctx);
+
                 response["activeSessions"] = activeSessions.size();
                 response["lastUpdate"] = std::chrono::duration_cast<std::chrono::seconds>(
                     std::chrono::system_clock::now().time_since_epoch()).count();
-                
+
                 nlohmann::json sessionsArray = nlohmann::json::array();
                 for (const auto& sessionId : activeSessions) {
                     nlohmann::json sessionJson = {
                         {"sessionId", sessionId},
-                        {"status", g_crawlerManager->getCrawlStatus(sessionId)}
+                        {"status", g_crawlerManager->getCrawlStatus(sessionId, ctx)}
                     };
-                    
+
                     if (includeResults) {
-                        auto results = g_crawlerManager->getCrawlResults(sessionId);
+                        auto results = g_crawlerManager->getCrawlResults(sessionId, ctx);
                         sessionJson["totalCrawled"] = static_cast<int>(results.size());
                     }
-                    
+
                     sessionsArray.push_back(sessionJson);
                 }
                 

--- a/src/crawler/CrawlerManager.cpp
+++ b/src/crawler/CrawlerManager.cpp
@@ -42,7 +42,7 @@ CrawlerManager::~CrawlerManager() {
     LOG_INFO("CrawlerManager shutdown complete");
 }
 
-std::string CrawlerManager::startCrawl(const std::string& url, const CrawlConfig& config, bool force, CrawlCompletionCallback completionCallback) {
+std::string CrawlerManager::startCrawl(const std::string& url, const CrawlConfig& config, bool force, CrawlCompletionCallback completionCallback, const std::string& ownerUserId) {
     // Check if we've reached the maximum concurrent sessions limit
     size_t currentSessions = getActiveSessionCount();
     
@@ -76,7 +76,7 @@ std::string CrawlerManager::startCrawl(const std::string& url, const CrawlConfig
         
         // Create crawl session with completion callback
         LOG_DEBUG("CrawlerManager::startCrawl - Creating crawl session for session: " + sessionId);
-        auto session = std::make_unique<CrawlSession>(sessionId, std::move(crawler), std::move(completionCallback));
+        auto session = std::make_unique<CrawlSession>(sessionId, std::move(crawler), std::move(completionCallback), ownerUserId);
         
         // Add seed URL to the crawler
         LOG_DEBUG("CrawlerManager::startCrawl - Adding seed URL for session: " + sessionId);
@@ -410,6 +410,77 @@ std::unique_ptr<Crawler> CrawlerManager::createCrawler(const CrawlConfig& config
             CrawlLogger::broadcastLog("🤖 SPA rendering enabled for session with browserless URL: " + config.browserlessUrl, "info");
         }
     }
-    
+
     return crawler;
+}
+
+// =====================================================================
+// User-aware (issue #13): same semantics as the legacy variants but only
+// returns data if the calling user owns the session or is an admin.
+// Sessions with empty ownerUserId (created via legacy startCrawl path)
+// remain accessible to any caller to preserve back-compat for internal
+// callers (Celery scheduler, system jobs).
+// =====================================================================
+
+bool CrawlerManager::canAccess(const std::string& sessionOwnerId,
+                               const search_engine::auth::AuthContext& ctx) {
+    if (sessionOwnerId.empty()) return true;          // legacy / system session
+    if (ctx.isAdmin()) return true;
+    return ctx.userId == sessionOwnerId;
+}
+
+std::vector<CrawlResult> CrawlerManager::getCrawlResults(
+    const std::string& sessionId, const search_engine::auth::AuthContext& ctx) {
+    std::lock_guard<std::mutex> lock(sessionsMutex_);
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) return {};
+    if (!canAccess(it->second->userId, ctx)) {
+        LOG_WARNING("Access denied to session " + sessionId + " for user " + ctx.userId);
+        return {};
+    }
+    return it->second->crawler->getResults();
+}
+
+std::string CrawlerManager::getCrawlStatus(
+    const std::string& sessionId, const search_engine::auth::AuthContext& ctx) {
+    std::lock_guard<std::mutex> lock(sessionsMutex_);
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) return "not_found";
+    if (!canAccess(it->second->userId, ctx)) {
+        // Don't leak existence to non-owners.
+        return "not_found";
+    }
+    if (it->second->isCompleted) return "completed";
+    auto results = it->second->crawler->getResults();
+    if (results.empty()) return "starting";
+    bool hasActive = false;
+    for (const auto& r : results) {
+        if (r.crawlStatus == "queued" || r.crawlStatus == "downloading") { hasActive = true; break; }
+    }
+    return hasActive ? "crawling" : "completed";
+}
+
+bool CrawlerManager::stopCrawl(const std::string& sessionId,
+                               const search_engine::auth::AuthContext& ctx) {
+    {
+        std::lock_guard<std::mutex> lock(sessionsMutex_);
+        auto it = sessions_.find(sessionId);
+        if (it == sessions_.end()) return false;
+        if (!canAccess(it->second->userId, ctx)) {
+            LOG_WARNING("stopCrawl denied for user " + ctx.userId + " on session " + sessionId);
+            return false;
+        }
+    }
+    return stopCrawl(sessionId);
+}
+
+std::vector<std::string> CrawlerManager::getActiveSessions(
+    const search_engine::auth::AuthContext& ctx) {
+    std::lock_guard<std::mutex> lock(sessionsMutex_);
+    std::vector<std::string> out;
+    for (const auto& [id, s] : sessions_) {
+        if (s->isCompleted) continue;
+        if (canAccess(s->userId, ctx)) out.push_back(id);
+    }
+    return out;
 } 

--- a/src/crawler/CrawlerManager.h
+++ b/src/crawler/CrawlerManager.h
@@ -11,6 +11,7 @@
 #include "Crawler.h"
 #include "models/CrawlConfig.h"
 #include "models/CrawlResult.h"
+#include "../../include/search_engine/auth/User.h"
 #include "../../include/search_engine/storage/ContentStorage.h"
 
 // Forward declaration for completion callback
@@ -33,19 +34,22 @@ struct CrawlSession {
     std::atomic<bool> isCompleted{false};
     std::thread crawlThread;
     CrawlCompletionCallback completionCallback;
-    
-    CrawlSession(const std::string& sessionId, std::unique_ptr<Crawler> crawlerInstance, 
-                 CrawlCompletionCallback callback = nullptr)
+    std::string userId;  // Owner; empty = no owner (legacy / anonymous). #13
+
+    CrawlSession(const std::string& sessionId, std::unique_ptr<Crawler> crawlerInstance,
+                 CrawlCompletionCallback callback = nullptr,
+                 std::string ownerUserId = "")
         : id(sessionId), crawler(std::move(crawlerInstance)), createdAt(std::chrono::system_clock::now()),
-          completionCallback(std::move(callback)) {}
-    
+          completionCallback(std::move(callback)), userId(std::move(ownerUserId)) {}
+
     CrawlSession(CrawlSession&& other) noexcept
         : id(std::move(other.id))
         , crawler(std::move(other.crawler))
         , createdAt(other.createdAt)
         , isCompleted(other.isCompleted.load())
         , crawlThread(std::move(other.crawlThread))
-        , completionCallback(std::move(other.completionCallback)) {}
+        , completionCallback(std::move(other.completionCallback))
+        , userId(std::move(other.userId)) {}
     
     CrawlSession(const CrawlSession&) = delete;
     CrawlSession& operator=(const CrawlSession&) = delete;
@@ -65,26 +69,27 @@ public:
      * @param completionCallback Optional callback to execute when crawl completes
      * @return Session ID of the started crawl
      */
-    std::string startCrawl(const std::string& url, const CrawlConfig& config, bool force = false, 
-                          CrawlCompletionCallback completionCallback = nullptr);
-    
-    // Get crawl results by session ID
+    std::string startCrawl(const std::string& url, const CrawlConfig& config, bool force = false,
+                          CrawlCompletionCallback completionCallback = nullptr,
+                          const std::string& ownerUserId = "");
+
     std::vector<CrawlResult> getCrawlResults(const std::string& sessionId);
-    
-    // Get crawl status by session ID
     std::string getCrawlStatus(const std::string& sessionId);
-    
-    // Stop a specific crawl session
     bool stopCrawl(const std::string& sessionId);
-    
-    // Get all active sessions
     std::vector<std::string> getActiveSessions();
-    
-    // Clean up completed sessions (called periodically)
     void cleanupCompletedSessions();
-    
-    // Get session count for monitoring
     size_t getActiveSessionCount();
+
+    std::vector<CrawlResult> getCrawlResults(const std::string& sessionId,
+                                             const search_engine::auth::AuthContext& ctx);
+    std::string getCrawlStatus(const std::string& sessionId,
+                               const search_engine::auth::AuthContext& ctx);
+    bool stopCrawl(const std::string& sessionId,
+                   const search_engine::auth::AuthContext& ctx);
+    std::vector<std::string> getActiveSessions(const search_engine::auth::AuthContext& ctx);
+
+    static bool canAccess(const std::string& sessionOwnerId,
+                          const search_engine::auth::AuthContext& ctx);
     
     // Get access to storage for logging
     std::shared_ptr<search_engine::storage::ContentStorage> getStorage() const { return storage_; }

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -75,6 +75,8 @@ set(STORAGE_SOURCES
     LinkBlock.cpp
     LinkBlockStorage.cpp
     LinkClickAnalyticsStorage.cpp
+    ../auth/PasswordHasher.cpp
+    ../auth/Jwt.cpp
     ../infrastructure.cpp
 )
 

--- a/tests/crawler/CMakeLists.txt
+++ b/tests/crawler/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(crawler_tests
     robots_txt_parser_tests.cpp
     url_frontier_tests.cpp
     page_fetcher_tests.cpp
+    auth_tests.cpp
     ../../src/storage/ContentStorage.cpp
     ../../src/storage/MongoDBStorage.cpp
 )

--- a/tests/crawler/auth_tests.cpp
+++ b/tests/crawler/auth_tests.cpp
@@ -1,0 +1,176 @@
+#include <catch2/catch_test_macros.hpp>
+#include "search_engine/auth/User.h"
+#include "search_engine/auth/UserStore.h"
+#include "search_engine/auth/PasswordHasher.h"
+#include "search_engine/auth/Base64Url.h"
+#include "search_engine/auth/Jwt.h"
+#include "search_engine/crawler/CrawlerManager.h"
+
+#include <thread>
+#include <chrono>
+
+using namespace search_engine::auth;
+using namespace std::chrono_literals;
+
+// =====================================================================
+// Base64Url
+// =====================================================================
+TEST_CASE("Base64Url roundtrip", "[auth][base64]") {
+    std::string original = "Hello, World! This is a test \xff\x00 with binary.";
+    auto encoded = Base64Url::encode(original);
+    REQUIRE(encoded.find('+') == std::string::npos);
+    REQUIRE(encoded.find('/') == std::string::npos);
+    REQUIRE(encoded.find('=') == std::string::npos);
+    auto decoded = Base64Url::decode(encoded);
+    REQUIRE(std::string(decoded.begin(), decoded.end()) == original);
+}
+
+TEST_CASE("Base64Url empty input", "[auth][base64]") {
+    REQUIRE(Base64Url::encode("").empty());
+    REQUIRE(Base64Url::decode("").empty());
+}
+
+TEST_CASE("Base64Url rejects bad chars", "[auth][base64]") {
+    REQUIRE(Base64Url::decode("ab!!cd").empty());
+    REQUIRE(Base64Url::decode("ab+cd").empty());  // '+' not valid in URL-safe alphabet
+}
+
+// =====================================================================
+// PasswordHasher
+// =====================================================================
+TEST_CASE("PasswordHasher roundtrip", "[auth][password]") {
+    auto stored = PasswordHasher::hash("hunter2-strong-pw", 1000);  // low iters for test speed
+    REQUIRE_FALSE(stored.empty());
+    REQUIRE(PasswordHasher::verify("hunter2-strong-pw", stored));
+    REQUIRE_FALSE(PasswordHasher::verify("wrong", stored));
+}
+
+TEST_CASE("PasswordHasher salts unique hashes", "[auth][password]") {
+    auto a = PasswordHasher::hash("same-password", 1000);
+    auto b = PasswordHasher::hash("same-password", 1000);
+    REQUIRE(a != b);                                  // different salt
+    REQUIRE(PasswordHasher::verify("same-password", a));
+    REQUIRE(PasswordHasher::verify("same-password", b));
+}
+
+TEST_CASE("PasswordHasher rejects malformed stored hash", "[auth][password]") {
+    REQUIRE_FALSE(PasswordHasher::verify("p", "not-a-real-hash"));
+    REQUIRE_FALSE(PasswordHasher::verify("p", ""));
+    REQUIRE_FALSE(PasswordHasher::verify("p", "1000$$$"));
+}
+
+// =====================================================================
+// JWT
+// =====================================================================
+TEST_CASE("JWT issue and verify roundtrip", "[auth][jwt]") {
+    JwtIssuer issuer("test-secret-1234567890");
+    User u;
+    u.id = "u_123";
+    u.username = "alice";
+    u.role = Role::USER;
+    auto token = issuer.issue(u, std::chrono::seconds(60));
+    REQUIRE(token.find('.') != std::string::npos);
+
+    auto claims = issuer.verify(token);
+    REQUIRE(claims.has_value());
+    REQUIRE(claims->sub == "u_123");
+    REQUIRE(claims->username == "alice");
+    REQUIRE(claims->role == Role::USER);
+    REQUIRE(claims->exp > claims->iat);
+}
+
+TEST_CASE("JWT rejects token with bad signature", "[auth][jwt]") {
+    JwtIssuer issuer("secret-A");
+    User u; u.id = "u"; u.username = "n"; u.role = Role::ADMIN;
+    auto token = issuer.issue(u, std::chrono::seconds(60));
+
+    JwtIssuer wrong("secret-B");
+    REQUIRE_FALSE(wrong.verify(token).has_value());
+}
+
+TEST_CASE("JWT rejects tampered payload", "[auth][jwt]") {
+    JwtIssuer issuer("test-secret");
+    User u; u.id = "alice"; u.username = "alice"; u.role = Role::USER;
+    auto token = issuer.issue(u, std::chrono::seconds(60));
+
+    // Flip a character in the middle of the payload segment.
+    auto firstDot = token.find('.');
+    REQUIRE(firstDot != std::string::npos);
+    auto secondDot = token.find('.', firstDot + 1);
+    REQUIRE(secondDot != std::string::npos);
+    auto mid = (firstDot + secondDot) / 2;
+    std::string tampered = token;
+    tampered[mid] = (token[mid] == 'a') ? 'b' : 'a';
+    REQUIRE_FALSE(issuer.verify(tampered).has_value());
+}
+
+TEST_CASE("JWT rejects expired token", "[auth][jwt]") {
+    JwtIssuer issuer("s");
+    User u; u.id = "u"; u.username = "n"; u.role = Role::USER;
+    // 1-second expiry; wait 2 seconds.
+    auto token = issuer.issue(u, std::chrono::seconds(1));
+    std::this_thread::sleep_for(1100ms);
+    REQUIRE_FALSE(issuer.verify(token).has_value());
+}
+
+TEST_CASE("JWT rejects malformed token", "[auth][jwt]") {
+    JwtIssuer issuer("s");
+    REQUIRE_FALSE(issuer.verify("").has_value());
+    REQUIRE_FALSE(issuer.verify("not.a.jwt").has_value());
+    REQUIRE_FALSE(issuer.verify("only-one-segment").has_value());
+    REQUIRE_FALSE(issuer.verify("only.two").has_value());
+}
+
+// =====================================================================
+// UserStore
+// =====================================================================
+TEST_CASE("InMemoryUserStore basic CRUD", "[auth][userstore]") {
+    InMemoryUserStore store;
+    User u;
+    u.username = "bob";
+    u.passwordHash = "x";
+    REQUIRE(store.create(u));
+    REQUIRE_FALSE(u.id.empty());
+    REQUIRE(store.size() == 1);
+
+    auto found = store.findByUsername("bob");
+    REQUIRE(found.has_value());
+    REQUIRE(found->id == u.id);
+    REQUIRE(store.findById(u.id).has_value());
+}
+
+TEST_CASE("InMemoryUserStore rejects duplicate username", "[auth][userstore]") {
+    InMemoryUserStore store;
+    User u1; u1.username = "carol"; u1.passwordHash = "x";
+    User u2; u2.username = "carol"; u2.passwordHash = "y";
+    REQUIRE(store.create(u1));
+    REQUIRE_FALSE(store.create(u2));
+    REQUIRE(store.size() == 1);
+}
+
+// =====================================================================
+// CrawlerManager::canAccess (session ownership policy)
+// =====================================================================
+TEST_CASE("canAccess: legacy session with empty owner is open", "[auth][isolation]") {
+    AuthContext anon;  // empty userId, USER role
+    REQUIRE(CrawlerManager::canAccess("", anon));
+    AuthContext user{"u1", "u", Role::USER};
+    REQUIRE(CrawlerManager::canAccess("", user));
+}
+
+TEST_CASE("canAccess: owner sees their own session", "[auth][isolation]") {
+    AuthContext alice{"u_alice", "alice", Role::USER};
+    REQUIRE(CrawlerManager::canAccess("u_alice", alice));
+}
+
+TEST_CASE("canAccess: stranger blocked from another user's session", "[auth][isolation]") {
+    AuthContext bob{"u_bob", "bob", Role::USER};
+    REQUIRE_FALSE(CrawlerManager::canAccess("u_alice", bob));
+}
+
+TEST_CASE("canAccess: admin sees everyone's session", "[auth][isolation]") {
+    AuthContext admin{"u_admin", "root", Role::ADMIN};
+    REQUIRE(CrawlerManager::canAccess("u_alice", admin));
+    REQUIRE(CrawlerManager::canAccess("u_bob", admin));
+    REQUIRE(CrawlerManager::canAccess("", admin));
+}


### PR DESCRIPTION
Adds an authentication subsystem (users, password hashing, JWT) and
enforces **per-user ownership** on crawl sessions, with role-based
access control (`USER`, `ADMIN`). Sessions created by user A are
invisible to user B; admins see everyone's.

Closes #13

## Acceptance criteria (from the issue)

- [x] Users can register and log in (JWT-based authentication)
- [x] Each `CrawlSession` is linked to a `userId`
- [x] Only the session owner (or admin) can access session data
- [x] Role-based access control is enforced (admin, user)
- [x] Unit tests for user session isolation

## Architecture

### New module: `search_engine/auth`

| File | Role |
|------|------|
| `User.h` | `User` struct, `Role` enum (USER / ADMIN), `AuthContext` value type |
| `UserStore.h` | `IUserStore` interface + thread-safe `InMemoryUserStore` |
| `PasswordHasher.{h,cpp}` | PBKDF2-HMAC-SHA256 via OpenSSL. Encoded format: `iter$saltB64$hashB64`. 100k iterations by default; verify embeds the iteration count so existing hashes keep working |
| `Base64Url.h` | Header-only RFC 4648 §5 URL-safe base64 (no padding) |
| `Jwt.{h,cpp}` | HS256 `JwtIssuer` / `verify` backed by OpenSSL HMAC-SHA256. Claims: `sub`, `username`, `role`, `iat`, `exp`. Constant-time signature compare. Secret from `JWT_SECRET` env var with a noisy dev fallback |


### API endpoints (`AuthController`)

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/auth/register` | `{username, password, role?}` → `201 {id, username, role}` (409 on duplicate; 8+ char password) |
| POST | `/api/auth/login` | `{username, password}` → `{token, tokenType, user}` (same 401 for unknown user or bad password to prevent enumeration) |
| GET | `/api/auth/me` | Bearer required → current user |

`AuthController::extractAuth(req)` static helper reads the
`Authorization: Bearer …` header and resolves it to an `AuthContext`
for use by other controllers.

### SearchController gating

- `POST /api/crawl/add-site` — requires Bearer; authenticated user
  becomes the session owner. `stopPreviousSessions` only affects
  sessions visible to the caller.
- `GET /api/crawl/status` — requires Bearer; non-admin callers see
  only their own sessions.

## Examples

```bash
# Register
curl -X POST http://localhost:3000/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username":"alice","password":"alice-strong-pw"}'

# Login → get JWT
TOKEN=$(curl -s -X POST http://localhost:3000/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"alice","password":"alice-strong-pw"}' | jq -r .token)

# Start a crawl as alice
curl -X POST http://localhost:3000/api/crawl/add-site \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"url":"https://example.com","maxPages":5}'

# bob can't see alice's session
curl -H "Authorization: Bearer $BOB_TOKEN" \
  "http://localhost:3000/api/crawl/status?sessionId=<alice_session_id>"
# → 404 (not_found)
```